### PR TITLE
[Android] Fix decoding issues with some UTF-8 strings

### DIFF
--- a/android/src/main/java/com/gzip/GzipModule.java
+++ b/android/src/main/java/com/gzip/GzipModule.java
@@ -81,7 +81,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
     gis.close();
     is.close();
     os.close();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       return os.toString(StandardCharsets.UTF_8);
     } else {
       return os.toString("UTF-8");

--- a/android/src/main/java/com/gzip/GzipModule.java
+++ b/android/src/main/java/com/gzip/GzipModule.java
@@ -81,11 +81,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
     gis.close();
     is.close();
     os.close();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      return os.toString(StandardCharsets.UTF_8);
-    } else {
-      return os.toString("UTF-8");
-    }
+    return os.toString(StandardCharsets.UTF_8);
   }
 
 }

--- a/android/src/main/java/com/gzip/GzipModule.java
+++ b/android/src/main/java/com/gzip/GzipModule.java
@@ -7,6 +7,7 @@ import android.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -20,6 +21,7 @@ import com.facebook.react.module.annotations.ReactModule;
 public class GzipModule extends ReactContextBaseJavaModule {
   public static final String NAME = "Gzip";
   public static final String ER_FAILURE = "ERROR_FAILED";
+  private static final int BUFFER_SIZE = 1024;
 
   public GzipModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -50,16 +52,16 @@ public class GzipModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void deflate(@NonNull final String data, @NonNull final Promise promise) {
     try {
-      promise.resolve(Base64.encodeToString(compress(data, "UTF-8"), Base64.NO_WRAP));
+      promise.resolve(Base64.encodeToString(compress(data), Base64.NO_WRAP));
     } catch (final Throwable ex) {
       promise.reject(ER_FAILURE, ex);
     }
   }
 
-  public static byte[] compress(String string, String charset) throws IOException {
+  public static byte[] compress(String string) throws IOException {
     ByteArrayOutputStream os = new ByteArrayOutputStream(string.length());
     GZIPOutputStream gos = new GZIPOutputStream(os);
-    gos.write(string.getBytes(charset));
+    gos.write(string.getBytes(StandardCharsets.UTF_8));
     gos.close();
     byte[] compressed = os.toByteArray();
     os.close();
@@ -67,7 +69,6 @@ public class GzipModule extends ReactContextBaseJavaModule {
   }
 
   public static String decompress(byte[] compressed) throws IOException {
-    final int BUFFER_SIZE = 32;
     ByteArrayInputStream is = new ByteArrayInputStream(compressed);
     GZIPInputStream gis = new GZIPInputStream(is, BUFFER_SIZE);
     ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -79,7 +80,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
     gis.close();
     is.close();
     os.close();
-    return os.toString("UTF-8");
+    return os.toString(StandardCharsets.UTF_8);
   }
 
 }

--- a/android/src/main/java/com/gzip/GzipModule.java
+++ b/android/src/main/java/com/gzip/GzipModule.java
@@ -20,8 +20,9 @@ import com.facebook.react.module.annotations.ReactModule;
 public class GzipModule extends ReactContextBaseJavaModule {
   public static final String NAME = "Gzip";
   public static final String ER_FAILURE = "ERROR_FAILED";
-  private static final int BUFFER_SIZE = 1024;
-  private static final String CHARSET_NAME = "UTF-8";
+  
+  // Default BUFFER_SIZE for GZIPInputStream is 512
+  private static final int GZIP_DEFAULT_BUFFER_SIZE = 512;
 
   public GzipModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -61,7 +62,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
   public static byte[] compress(String string) throws IOException {
     ByteArrayOutputStream os = new ByteArrayOutputStream(string.length());
     GZIPOutputStream gos = new GZIPOutputStream(os);
-    gos.write(string.getBytes(CHARSET_NAME));
+    gos.write(string.getBytes());
     gos.close();
     byte[] compressed = os.toByteArray();
     os.close();
@@ -70,9 +71,9 @@ public class GzipModule extends ReactContextBaseJavaModule {
 
   public static String decompress(byte[] compressed) throws IOException {
     ByteArrayInputStream is = new ByteArrayInputStream(compressed);
-    GZIPInputStream gis = new GZIPInputStream(is, BUFFER_SIZE);
+    GZIPInputStream gis = new GZIPInputStream(is);
     ByteArrayOutputStream os = new ByteArrayOutputStream();
-    byte[] data = new byte[BUFFER_SIZE];
+    byte[] data = new byte[GZIP_DEFAULT_BUFFER_SIZE];
     int bytesRead;
     while ((bytesRead = gis.read(data)) != -1) {
       os.write(data, 0, bytesRead);
@@ -80,7 +81,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
     gis.close();
     is.close();
     os.close();
-    return os.toString(CHARSET_NAME);
+    return os.toString();
   }
 
 }

--- a/android/src/main/java/com/gzip/GzipModule.java
+++ b/android/src/main/java/com/gzip/GzipModule.java
@@ -7,19 +7,14 @@ import android.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-import java.util.zip.Inflater;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
-
-import com.facebook.react.bridge.ReadableArray;
 
 @ReactModule(name = GzipModule.NAME)
 public class GzipModule extends ReactContextBaseJavaModule {
@@ -55,16 +50,16 @@ public class GzipModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void deflate(@NonNull final String data, @NonNull final Promise promise) {
     try {
-      promise.resolve(Base64.encodeToString(compress(data), Base64.NO_WRAP));
+      promise.resolve(Base64.encodeToString(compress(data, "UTF-8"), Base64.NO_WRAP));
     } catch (final Throwable ex) {
       promise.reject(ER_FAILURE, ex);
     }
   }
 
-  public static byte[] compress(String string) throws IOException {
+  public static byte[] compress(String string, String charset) throws IOException {
     ByteArrayOutputStream os = new ByteArrayOutputStream(string.length());
     GZIPOutputStream gos = new GZIPOutputStream(os);
-    gos.write(string.getBytes());
+    gos.write(string.getBytes(charset));
     gos.close();
     byte[] compressed = os.toByteArray();
     os.close();
@@ -75,15 +70,16 @@ public class GzipModule extends ReactContextBaseJavaModule {
     final int BUFFER_SIZE = 32;
     ByteArrayInputStream is = new ByteArrayInputStream(compressed);
     GZIPInputStream gis = new GZIPInputStream(is, BUFFER_SIZE);
-    StringBuilder string = new StringBuilder();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
     byte[] data = new byte[BUFFER_SIZE];
     int bytesRead;
     while ((bytesRead = gis.read(data)) != -1) {
-      string.append(new String(data, 0, bytesRead));
+      os.write(data, 0, bytesRead);
     }
     gis.close();
     is.close();
-    return string.toString();
+    os.close();
+    return os.toString("UTF-8");
   }
 
 }

--- a/android/src/main/java/com/gzip/GzipModule.java
+++ b/android/src/main/java/com/gzip/GzipModule.java
@@ -2,13 +2,11 @@ package com.gzip;
 
 import androidx.annotation.NonNull;
 
-import android.os.Build;
 import android.util.Base64;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -23,6 +21,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
   public static final String NAME = "Gzip";
   public static final String ER_FAILURE = "ERROR_FAILED";
   private static final int BUFFER_SIZE = 1024;
+  private static final String CHARSET_NAME = "UTF-8";
 
   public GzipModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -62,7 +61,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
   public static byte[] compress(String string) throws IOException {
     ByteArrayOutputStream os = new ByteArrayOutputStream(string.length());
     GZIPOutputStream gos = new GZIPOutputStream(os);
-    gos.write(string.getBytes(StandardCharsets.UTF_8));
+    gos.write(string.getBytes(CHARSET_NAME));
     gos.close();
     byte[] compressed = os.toByteArray();
     os.close();
@@ -81,7 +80,7 @@ public class GzipModule extends ReactContextBaseJavaModule {
     gis.close();
     is.close();
     os.close();
-    return os.toString(StandardCharsets.UTF_8);
+    return os.toString(CHARSET_NAME);
   }
 
 }

--- a/android/src/main/java/com/gzip/GzipModule.java
+++ b/android/src/main/java/com/gzip/GzipModule.java
@@ -2,6 +2,7 @@ package com.gzip;
 
 import androidx.annotation.NonNull;
 
+import android.os.Build;
 import android.util.Base64;
 
 import java.io.ByteArrayInputStream;
@@ -80,7 +81,11 @@ public class GzipModule extends ReactContextBaseJavaModule {
     gis.close();
     is.close();
     os.close();
-    return os.toString(StandardCharsets.UTF_8);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      return os.toString(StandardCharsets.UTF_8);
+    } else {
+      return os.toString("UTF-8");
+    }
   }
 
 }


### PR DESCRIPTION
Fix based on the issue I had with Polish and French characters. 

#### Changes:
- Increase to BUFFER_SIZE to resolve issue with decoding. 
- Remove unused imports.
- Use ByteArrayOutputStream instead of StringBuilder.

When you read the compressed data in chunks using the GZIPInputStream, you need to ensure that the buffer size is large enough to hold the entire chunk of data. If the buffer size is too small, the read method may not be able to read the entire chunk of data in one go, and you may end up with incomplete characters in the buffer. If the buffer contains incomplete characters, the String constructor may not be able to decode them correctly, and you may end up with corrupted characters or question marks in the output string.

#### Why ByteArrayOutputStream?

The BUFFER_SIZE used in the StringBuilder and ByteArrayOutputStream is not related to the character encoding, but rather to the size of the buffer used for reading the compressed data.

In the case of StringBuilder, the BUFFER_SIZE is used to read the compressed data from the GZIPInputStream in chunks, and then append the chunks to the StringBuilder. However, if the buffer size is too small, it may not be able to read the entire compressed data in one chunk, and may need to read the data in multiple chunks. This can result in incomplete or corrupted data being appended to the StringBuilder, which can break the character encoding.

On the other hand, in the case of ByteArrayOutputStream, the BUFFER_SIZE is used to write the compressed data to the GZIPOutputStream in chunks, and then collect the chunks in the ByteArrayOutputStream. However, since the compressed data is binary data, it does not have a character encoding, and therefore the buffer size does not affect the encoding.

#### Example of currect, wrong, behaviour: 

Data chunk is too small, and `ś` character is malformed.

![261681193-ace1be50-ecce-47f1-a91a-b51bb01a7157](https://github.com/ammarahm-ed/react-native-gzip/assets/7620331/da28e4e1-3a8c-4045-8af4-9d1d5ecd3558)

![MicrosoftTeams-image (1)](https://github.com/ammarahm-ed/react-native-gzip/assets/7620331/64ae7678-14c2-4f35-9439-9444accaef70)




