### PR TITLE
fix: Android RN 0.72+ Support - Update build.gradle w/ Namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,11 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.gzip"
+  }
+
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
   defaultConfig {


### PR DESCRIPTION
Add namespace for React Native 0.72+